### PR TITLE
Enable deleting patients in edit view

### DIFF
--- a/app/templates/edit_patient.html
+++ b/app/templates/edit_patient.html
@@ -128,18 +128,42 @@
 
                         <!-- Form Actions -->
                         <div class="d-flex justify-content-between mt-4 pt-3 border-top">
-                            <button type="button" 
-                                    class="btn btn-outline-danger" 
-                                    data-bs-toggle="modal" 
-                                    data-bs-target="#confirmCancel">
-                                <i class="bi bi-x-circle"></i> Cancel
-                            </button>
+                            <div>
+                                <button type="button" class="btn btn-outline-danger me-2" data-bs-toggle="modal" data-bs-target="#confirmDelete">
+                                    <i class="bi bi-trash"></i> Delete Patient
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#confirmCancel">
+                                    <i class="bi bi-x-circle"></i> Cancel
+                                </button>
+                            </div>
                             <button type="submit" class="btn btn-primary">
                                 <i class="bi bi-check-circle"></i> Save Changes
                             </button>
                         </div>
                     </form>
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Confirm Delete Modal -->
+<div class="modal fade" id="confirmDelete" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Confirm Delete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to permanently delete this patient? This action cannot be undone.</p>
+            </div>
+            <div class="modal-footer">
+                <form action="{{ url_for('main.delete_patient', id=patient.id) }}" method="POST" class="d-inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Yes, Delete</button>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a route to delete a single patient and their related data
- update the edit patient template with a delete button and confirmation modal

## Testing
- `pytest -q` *(fails: fixture 'api_key' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430930fc44832bb4aa5bc3c06c7403