### PR TITLE
Add basic marketing landing page

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -3433,3 +3433,9 @@ def bulk_delete_patients():
         }), 400
 
 
+
+@main.route("/landing")
+def landing_page():
+    """Public marketing landing page."""
+    return render_template("landing.html")
+

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -1,0 +1,46 @@
+{% extends 'base_auth.html' %}
+
+{% block title %}Welcome{% endblock %}
+
+{% block content %}
+<!-- Hero Section -->
+<section class="py-5 text-center text-white" style="background: linear-gradient(45deg, #2980b9, #2c3e50);">
+  <div class="container">
+    <h1 class="display-4 fw-bold">PhysioTracker CRM</h1>
+    <p class="lead">Gestiona tu consulta de fisioterapia de manera sencilla y eficiente.</p>
+    <a href="{{ url_for('auth.register') }}" class="btn btn-light btn-lg mt-3">Empieza ahora</a>
+  </div>
+</section>
+
+<!-- Features Section -->
+<section class="py-5">
+  <div class="container">
+    <div class="row g-4">
+      <div class="col-md-4 text-center">
+        <i class="bi bi-people display-4 text-primary"></i>
+        <h3 class="mt-3">Gestión de pacientes</h3>
+        <p>Registra tratamientos y controla la evolución de cada paciente.</p>
+      </div>
+      <div class="col-md-4 text-center">
+        <i class="bi bi-calendar-check display-4 text-primary"></i>
+        <h3 class="mt-3">Citas y agenda</h3>
+        <p>Sincroniza tus reservas con Calendly y mantén la agenda siempre al día.</p>
+      </div>
+      <div class="col-md-4 text-center">
+        <i class="bi bi-bar-chart-line display-4 text-primary"></i>
+        <h3 class="mt-3">Informes y análisis</h3>
+        <p>Genera reportes inteligentes con IA y analiza el rendimiento de tu clínica.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Call to Action -->
+<section class="py-5 bg-light text-center">
+  <div class="container">
+    <h2 class="fw-bold">¿Listo para potenciar tu consulta?</h2>
+    <p class="mb-4">Comienza gratis y descubre todas las ventajas de PhysioTracker.</p>
+    <a href="{{ url_for('auth.register') }}" class="btn btn-primary btn-lg">Probar gratis</a>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add simple landing page template
- serve new landing page at `/landing`

## Testing
- `pytest -q` *(fails: fixture 'api_key' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430bf22fe4832bab931fa54a87d6e5