### PR TITLE
Move language dropdown to Settings nav

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -509,6 +509,18 @@
                                         <i class="bi bi-calendar-plus"></i> {{ _('Calendly Settings') }}
                                     </a>
                                 </li>
+                                <li class="nav-item">
+                                    <div class="btn-group dropup">
+                                        <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                            <i class="bi bi-translate"></i> {{ get_locale_display_name(get_locale()) or 'Language' }}
+                                        </a>
+                                        <ul class="dropdown-menu dropdown-menu-end" id="languageDropdownMenu" aria-labelledby="languageDropdown">
+                                            {% for lang in BABEL_SUPPORTED_LOCALES %}
+                                                <li><a class="dropdown-item lang-option" href="#" data-lang="{{ lang }}">{{ get_locale_display_name(lang) }}</a></li>
+                                            {% endfor %}
+                                        </ul>
+                                    </div>
+                                </li>
                                 {# Add other general settings links here later #}
                             </ul>
                         </li>
@@ -554,6 +566,7 @@
                             </a>
                         </li>
                     </ul>
+                    <!--
                     <div class="mt-3">
                         <div class="btn-group dropup">
                             <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -566,6 +579,7 @@
                             </ul>
                         </div>
                     </div>
+                    -->
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- move language dropdown from sidebar footer to the Settings section
- comment out old dropdown in the sidebar footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509a21f9c8832bb0e148c0c5bd66ca